### PR TITLE
修改部分bug 新增部分内容 添加技能挽危

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -873,7 +873,7 @@ SkillCard *Engine::cloneSkillCard(const QString &name) const
 #ifndef USE_BUILDBOT
 QString Engine::getVersionNumber() const
 {
-    return "20150926";
+    return "20170101";
 }
 #endif
 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -88,7 +88,7 @@ bool Player::isWounded() const
 {
 
     foreach (const Player *p, getAliveSiblings()) {
-        if (p->phase != NotActive && p->hasLordSkill("guiming") && getKingdom() == "wu")
+        if ((p->phase != NotActive && p->hasLordSkill("guiming") && getKingdom() == "wu") || p->getMark("I_am_Wounded") > 0)
             return true;
     }
 

--- a/src/package/fire.cpp
+++ b/src/package/fire.cpp
@@ -99,6 +99,7 @@ public:
 
 QiangxiCard::QiangxiCard()
 {
+    mute = true;
 }
 
 bool QiangxiCard::targetFilter(const QList<const Player *> &targets, const Player *to_select, const Player *Self) const
@@ -119,6 +120,11 @@ void QiangxiCard::onEffect(const CardEffectStruct &effect) const
 {
     Room *room = effect.to->getRoom();
 
+    if (effect.from->hasSkill("jiwu")){
+        room->broadcastSkillInvoke("qiangxi", qrand() % 2 + 2);
+    } else {
+        room->broadcastSkillInvoke("qiangxi", 1);
+    }
     if (subcards.isEmpty())
         room->loseHp(effect.from);
 
@@ -384,6 +390,10 @@ public:
 
             if (!pangtong->faceUp())
                 pangtong->turnOver();
+            
+            if (pangtong->getHp() > 0)
+                return true;
+                
         }
 
         return false;

--- a/src/package/hegemony.cpp
+++ b/src/package/hegemony.cpp
@@ -415,9 +415,10 @@ void ShuangrenCard::onEffect(const CardEffectStruct &effect) const
 
         Slash *slash = new Slash(Card::NoSuit, 0);
         slash->setSkillName("_shuangren");
+        effect.from->broadcastSkillInvoke("slash");
         room->useCard(CardUseStruct(slash, effect.from, target));
     } else {
-        room->broadcastSkillInvoke("shuangren", 3);
+        room->broadcastSkillInvoke("shuangren", 2);
         room->setPlayerFlag(effect.from, "ShuangrenSkipPlay");
     }
 }
@@ -469,7 +470,7 @@ public:
     int getEffectIndex(const ServerPlayer *, const Card *card) const
     {
         if (card->isKindOf("Slash"))
-            return 2;
+            return NULL;
         else
             return 1;
     }
@@ -569,6 +570,10 @@ public:
                 room->moveCardTo(card, panfeng, Player::PlaceEquip);
             } else {
                 room->broadcastSkillInvoke(objectName(), 2);
+                if ((target->hasSkill("wanwei") || target->getMark("wanwei") != 0) && room->askForSkillInvoke(target, "wanwei")) {
+                    room->broadcastSkillInvoke("wanwei");
+                    card = room->askForCard(target, "..!", "@wanwei", QVariant(), Card::MethodNone);
+                }
                 room->throwCard(card, target, panfeng);
             }
         }

--- a/src/package/mountain.cpp
+++ b/src/package/mountain.cpp
@@ -58,7 +58,7 @@ void QiaobianCard::use(Room *room, ServerPlayer *zhanghe, QList<ServerPlayer *> 
         if (!from->hasEquip() && from->getJudgingArea().isEmpty())
             return;
 
-        int card_id = room->askForCardChosen(zhanghe, from, "ej", "qiaobian");
+        int card_id = room->askForCardChosen(zhanghe, from, "ej", "qiaobian", false, Card::MethodNone, QList<int>(), false, false);
         const Card *card = Sanguosha->getCard(card_id);
         Player::Place place = room->getCardPlace(card_id);
 

--- a/src/package/nostalgia.cpp
+++ b/src/package/nostalgia.cpp
@@ -1152,7 +1152,7 @@ public:
         QVariant data = QVariant::fromValue(from);
         if (from && !from->isNude() && room->askForSkillInvoke(simayi, "nosfankui", data)) {
             room->broadcastSkillInvoke(objectName());
-            int card_id = room->askForCardChosen(simayi, from, "he", "nosfankui");
+            int card_id = room->askForCardChosen(simayi, from, "he", "nosfankui", false, Card::MethodNone, QList<int>(), true);
             CardMoveReason reason(CardMoveReason::S_REASON_EXTRACTION, simayi->objectName());
             room->obtainCard(simayi, Sanguosha->getCard(card_id),
                 reason, room->getCardPlace(card_id) != Player::PlaceHand);
@@ -1327,6 +1327,9 @@ public:
 
     int getDrawNum(ServerPlayer *xuchu, int n) const
     {
+        if (n == 0)
+            return false;
+        
         Room *room = xuchu->getRoom();
         if (room->askForSkillInvoke(xuchu, objectName())) {
             room->broadcastSkillInvoke(objectName());
@@ -2547,3 +2550,4 @@ ADD_PACKAGE(NostalStandard)
 ADD_PACKAGE(NostalYJCM)
 ADD_PACKAGE(NostalYJCM2012)
 ADD_PACKAGE(NostalYJCM2013)
+ 

--- a/src/package/sp.cpp
+++ b/src/package/sp.cpp
@@ -1194,8 +1194,16 @@ public:
                         if (player->canDiscard(target, equip->getEffectiveId()))
                             dummy->addSubcard(equip);
                     }
-                    if (dummy->subcardsLength() > 0)
-                        room->throwCard(dummy, target, player);
+                    if (dummy->subcardsLength() > 0) {
+                        if (!target->isKongcheng() && (target->hasSkill("wanwei") || target->getMark("wanwei") == 0) && room->askForSkillInvoke(target, "wanwei")) {
+                            room->broadcastSkillInvoke("wanwei");
+							const Card *exchange_card = room->askForExchange(target, "xingwu", dummy->subcardsLength(), dummy->subcardsLength()), true, "@wanwei!");
+							foreach(int i, exchange_card->getSubcards())
+								dummy->addSubcard(i);
+                        } else {
+                            room->throwCard(dummy, target, player);
+                        }
+                    }
                     delete dummy;
                 }
             }
@@ -1846,7 +1854,12 @@ public:
                 if (choice == "weapon") {
                     room->broadcastSkillInvoke(objectName(), 1);
                     ServerPlayer *victim = room->askForPlayerChosen(player, weapon_players, objectName(), "@mumu-weapon");
-                    room->throwCard(victim->getWeapon(), victim, player);
+                    if ((victim->hasSkill("wanwei") || victim->getMark("wanwei") != 0) && room->askForSkillInvoke(victim, "wanwei")) {
+                        room->broadcastSkillInvoke("wanwei");
+                        room->throwCard(room->askForCard(victim, "..!", "@wanwei", QVariant(), Card::MethodNone), victim, player);
+                    } else {
+                        room->throwCard(victim->getWeapon(), victim, player);
+                    }
                     player->drawCards(1, objectName());
                 } else {
                     room->broadcastSkillInvoke(objectName(), 2);
@@ -2934,7 +2947,7 @@ public:
 
         room->broadcastSkillInvoke(objectName());
         ServerPlayer *target = room->askForPlayerChosen(hanba, targets, objectName(), "@fentian-choose", false, true);
-        int id = room->askForCardChosen(hanba, target, "he", objectName());
+        int id = room->askForCardChosen(hanba, target, "he", objectName(), false, Card::MethodNone, QList<int>(), false, false);
         hanba->addToPile("burn", id);
         return false;
     }

--- a/src/package/sp.cpp
+++ b/src/package/sp.cpp
@@ -1197,7 +1197,7 @@ public:
                     if (dummy->subcardsLength() > 0) {
                         if (!target->isKongcheng() && (target->hasSkill("wanwei") || target->getMark("wanwei") == 0) && room->askForSkillInvoke(target, "wanwei")) {
                             room->broadcastSkillInvoke("wanwei");
-							const Card *exchange_card = room->askForExchange(target, "xingwu", dummy->subcardsLength(), dummy->subcardsLength()), true, "@wanwei!");
+							const Card *exchange_card = room->askForExchange(target, "xingwu", dummy->subcardsLength(), dummy->subcardsLength(), true, "@wanwei!");
 							foreach(int i, exchange_card->getSubcards())
 								dummy->addSubcard(i);
                         } else {

--- a/src/package/special1v1.cpp
+++ b/src/package/special1v1.cpp
@@ -22,6 +22,9 @@ public:
 
     int getDrawNum(ServerPlayer *zhangliao, int n) const
     {
+        if (n == 0)
+            return false;
+        
         Room *room = zhangliao->getRoom();
         bool can_invoke = false;
         QList<ServerPlayer *> targets;

--- a/src/package/special3v3.cpp
+++ b/src/package/special3v3.cpp
@@ -57,6 +57,9 @@ public:
 
     int getDrawNum(ServerPlayer *zhugejin, int n) const
     {
+        if (n == 0)
+            return false;
+        
         Room *room = zhugejin->getRoom();
         bool invoke = false;
         if (room->getMode().startsWith("06_"))

--- a/src/package/standard-cards.cpp
+++ b/src/package/standard-cards.cpp
@@ -806,9 +806,9 @@ void AmazingGrace::clearRestCards(Room *room) const
     delete dummy;
 }
 
-void AmazingGrace::doPreAction(Room *room, const CardUseStruct &) const
+void AmazingGrace::doPreAction(Room *room, const CardUseStruct &use) const
 {
-    QList<int> card_ids = room->getNCards(room->getAllPlayers().length());
+    QList<int> card_ids = room->getNCards(use.to.length());
     room->fillAG(card_ids);
     room->setTag("AmazingGrace", IntList2VariantList(card_ids));
 }

--- a/src/package/standard-generals.cpp
+++ b/src/package/standard-generals.cpp
@@ -2710,6 +2710,7 @@ public:
     }
     bool onPhaseChange(ServerPlayer *player) const
     {
+        return false;
     }
 };
 

--- a/src/package/standard-generals.cpp
+++ b/src/package/standard-generals.cpp
@@ -410,9 +410,9 @@ public:
         Room *room = simayi->getRoom();
         for (int i = 0; i < damage.damage; i++) {
             QVariant data = QVariant::fromValue(from);
-            if (from && !from->isNude() && room->askForSkillInvoke(simayi, "fankui", data)) {
+            if (from && !from->isNude() && !(from == simayi && from->getCards("ej").isEmpty()) && room->askForSkillInvoke(simayi, "fankui", data)) {
                 room->broadcastSkillInvoke(objectName());
-                int card_id = room->askForCardChosen(simayi, from, "he", "fankui");
+                int card_id = room->askForCardChosen(simayi, from, "he", "fankui", false, Card::MethodNone, QList<int>(), true);
                 CardMoveReason reason(CardMoveReason::S_REASON_EXTRACTION, simayi->objectName());
                 room->obtainCard(simayi, Sanguosha->getCard(card_id),
                     reason, room->getCardPlace(card_id) != Player::PlaceHand);
@@ -2878,15 +2878,38 @@ public:
     }
 };
 
-class SuperGuanxing : public Guanxing
+class SuperGuanxing : public PhaseChangeSkill
 {
 public:
-    SuperGuanxing() : Guanxing()
+    SuperGuanxing() : PhaseChangeSkill("super_guanxing")
     {
-        setObjectName("super_guanxing");
+        frequency = Frequent;
     }
 
-    int getGuanxingNum(Room *) const
+    int getPriority(TriggerEvent) const
+    {
+        return 1;
+    }
+
+    bool onPhaseChange(ServerPlayer *zhuge) const
+    {
+        if (zhuge->getPhase() == Player::Start && zhuge->askForSkillInvoke(this)) {
+            Room *room = zhuge->getRoom();
+            room->broadcastSkillInvoke(objectName());
+
+            LogMessage log;
+            log.type = "$ViewDrawPile";
+            log.from = zhuge;
+            log.card_str = IntList2StringList(room->getNCards(5)).join("+");
+            room->sendLog(log, zhuge);
+
+            room->askForGuanxing(zhuge, room->getNCards(5));
+        }
+
+        return false;
+    }
+
+    int getGuanxingNum(Room *room) const
     {
         return 5;
     }

--- a/src/package/standard-generals.cpp
+++ b/src/package/standard-generals.cpp
@@ -2701,6 +2701,18 @@ public:
     }
 };
 
+class Wanwei : public PhaseChangeSkill
+{
+public:
+    Wanwei() : PhaseChangeSkill("wanwei")
+    {
+        frequency = Frequent;
+    }
+    bool onPhaseChange(ServerPlayer *player) const
+    {
+    }
+};
+
 void StandardPackage::addGenerals()
 {
     // Wei
@@ -2861,7 +2873,7 @@ void StandardPackage::addGenerals()
     addMetaObject<JianyanCard>();
     addMetaObject<GuoseCard>();
 
-    skills << new Xiaoxi << new NonCompulsoryInvalidity << new Jianyan;
+    skills << new Xiaoxi << new NonCompulsoryInvalidity << new Jianyan << new Wanwei;
 }
 
 class SuperZhiheng : public Zhiheng

--- a/src/package/standard-skillcards.cpp
+++ b/src/package/standard-skillcards.cpp
@@ -170,7 +170,14 @@ void FanjianCard::onEffect(const CardEffectStruct &effect) const
                         dummy->addSubcard(card);
                 }
                 if (dummy->subcardsLength() > 0)
-                    room->throwCard(dummy, target);
+                    if ((target->hasSkill("wanwei") || target->getMark("wanwei") != 0) && room->askForSkillInvoke(target, "wanwei")) {
+                        room->broadcastSkillInvoke("wanwei");
+                        const Card *exchange_card = room->askForExchange(target, "xuehen", dummy->subcardsLength(), dummy->subcardsLength(), true, "@wanwei!");
+                        foreach(int i, exchange_card->getSubcards())
+                            dummy->addSubcard(i);
+                    } else {
+                        room->throwCard(dummy, target);
+                    }
                 delete dummy;
             } else {
                 room->loseHp(target);

--- a/src/package/tw.cpp
+++ b/src/package/tw.cpp
@@ -68,12 +68,19 @@ public:
                 // If PlayerCardBox has changed for Room::askForCardChosen, please tell me, I will soon fix this.
                 if (player->askForSkillInvoke(this, data)) {
                     room->broadcastSkillInvoke(objectName(), 2);
-                    QList<int> hc = damage.to->handCards();
-                    qShuffle(hc);
-                    int n = damage.to->getHandcardNum() - qMax(damage.to->getHp(), 0);
-                    QList<int> to_discard = hc.mid(0, n - 1);
-                    DummyCard dc(to_discard);
-                    room->throwCard(&dc, damage.to, player);
+                    if ((damage.to->hasSkill("wanwei") || damage.to->getMark("wanwei") != 0) && room->askForSkillInvoke(damage.to, "wanwei")) {
+                        room->sendCompulsoryTriggerLog(damage.to, "wanwei");
+                        room->broadcastSkillInvoke("wanwei");
+                        const Card *exchange_card = room->askForExchange(damage.to, "baobian", damage.to->getHandcardNum() - qMax(damage.to->getHp(), 0), damage.to->getHandcardNum() - qMax(damage.to->getHp(), 0), true, "@wanwei!");
+                        room->throwCard(exchange_card, damage.to, player);
+                    } else {
+                        QList<int> hc = damage.to->handCards();
+                        qShuffle(hc);
+                        int n = damage.to->getHandcardNum() - qMax(damage.to->getHp(), 0);
+                        QList<int> to_discard = hc.mid(0, n - 1);
+                        DummyCard dc(to_discard);
+                        room->throwCard(&dc, damage.to, player);
+                    }
                 }
             }
         }

--- a/src/package/wind.cpp
+++ b/src/package/wind.cpp
@@ -554,6 +554,10 @@ public:
         } else {
             room->recover(zhoutai, RecoverStruct(zhoutai, NULL, 1 - zhoutai->getHp()));
         }
+            
+        if (zhoutai->getHp() > 0)
+            return true;
+        
         return false;
     }
 };

--- a/src/package/yjcm.cpp
+++ b/src/package/yjcm.cpp
@@ -374,18 +374,25 @@ public:
                     if (to->isNude())
                         return true;
                     room->setPlayerFlag(to, "xuanhuo_InTempMoving");
-                    int first_id = room->askForCardChosen(fazheng, to, "he", "xuanhuo");
-                    Player::Place original_place = room->getCardPlace(first_id);
                     DummyCard *dummy = new DummyCard;
-                    dummy->addSubcard(first_id);
-                    to->addToPile("#xuanhuo", dummy, false);
-                    if (!to->isNude()) {
-                        int second_id = room->askForCardChosen(fazheng, to, "he", "xuanhuo");
-                        dummy->addSubcard(second_id);
-                    }
+                    if ((victim->hasSkill("wanwei") || victim->getMark("wanwei") != 0) && room->askForSkillInvoke(victim, "wanwei")) {
+                        room->broadcastSkillInvoke("wanwei");
+                        const Card *exchange_card = room->askForExchange(victim, "xuanhuo", 2, 2, true, "@wanwei!");
+                        foreach(int i, exchange_card->getSubcards())
+                            dummy->addSubcard(i);
+                    } else {
+                        int first_id = room->askForCardChosen(fazheng, to, "he", "xuanhuo");
+                        Player::Place original_place = room->getCardPlace(first_id);
+                        dummy->addSubcard(first_id);
+                        to->addToPile("#xuanhuo", dummy, false);
+                        if (!to->isNude()) {
+                            int second_id = room->askForCardChosen(fazheng, to, "he", "xuanhuo");
+                            dummy->addSubcard(second_id);
+                        }
 
-                    //move the first card back temporarily
-                    room->moveCardTo(Sanguosha->getCard(first_id), to, original_place, false);
+                        room->moveCardTo(Sanguosha->getCard(first_id), to, original_place, false);
+                        //move the first card back temporarily
+                    }
                     room->setPlayerFlag(to, "-xuanhuo_InTempMoving");
                     room->moveCardTo(dummy, fazheng, Player::PlaceHand, false);
                     delete dummy;
@@ -465,7 +472,11 @@ public:
             return;
 
         if (lingtong->askForSkillInvoke(this)) {
-            room->broadcastSkillInvoke(objectName());
+            if (lingtong->hasSkill("jiwu")){
+                room->broadcastSkillInvoke(objectName(), qrand() % 2 + 3);
+            } else {
+                room->broadcastSkillInvoke(objectName(), qrand() % 2 + 1);
+            }
 
             ServerPlayer *first = room->askForPlayerChosen(lingtong, targets, "xuanfeng");
             ServerPlayer *second = NULL;

--- a/src/package/yjcm2012.cpp
+++ b/src/package/yjcm2012.cpp
@@ -258,6 +258,9 @@ public:
 
     int getDrawNum(ServerPlayer *caozhang, int n) const
     {
+        if (n == 0)
+            return false;
+        
         Room *room = caozhang->getRoom();
         QString choice = room->askForChoice(caozhang, objectName(), "jiang+chi+cancel");
         if (choice == "cancel")
@@ -475,6 +478,9 @@ public:
             room->recover(liaohua, RecoverStruct(liaohua, NULL, getKingdoms(room) - liaohua->getHp()));
 
             liaohua->turnOver();
+            
+            if (liaohua->getHp() > 0)
+                return true;
         }
         return false;
     }
@@ -954,7 +960,7 @@ ChunlaoWineCard::ChunlaoWineCard()
     will_throw = false;
 }
 
-void ChunlaoWineCard::use(Room *room, ServerPlayer *, QList<ServerPlayer *> &) const
+void ChunlaoWineCard::use(Room *room, ServerPlayer *source, QList<ServerPlayer *> &) const
 {
     ServerPlayer *who = room->getCurrentDyingPlayer();
     if (!who) return;

--- a/src/package/yjcm2013.cpp
+++ b/src/package/yjcm2013.cpp
@@ -400,7 +400,7 @@ public:
         CardUseStruct use = data.value<CardUseStruct>();
         if (use.card->isNDTrick() || use.card->isKindOf("BasicCard")) {
             jianyong->setFlags("-QiaoshuiSuccess");
-            if (Sanguosha->currentRoomState()->getCurrentCardUseReason() != CardUseStruct::CARD_USE_REASON_PLAY)
+            if (use.card->isKindOf("Jink") || use.card->isKindOf("Nullification"))
                 return false;
 
             QList<ServerPlayer *> available_targets;
@@ -574,7 +574,7 @@ bool XiansiCard::targetFilter(const QList<const Player *> &targets, const Player
 void XiansiCard::onEffect(const CardEffectStruct &effect) const
 {
     if (effect.to->isNude()) return;
-    int id = effect.from->getRoom()->askForCardChosen(effect.from, effect.to, "he", "xiansi");
+    int id = effect.from->getRoom()->askForCardChosen(effect.from, effect.to, "he", "xiansi", false, Card::MethodNone, QList<int>(), false, false);
     effect.from->addToPile("counter", id);
 }
 
@@ -820,7 +820,12 @@ public:
         if (room->askForCard(target, "..", "@duodao-get", data, objectName())) {
             if (damage.from && damage.from->getWeapon()) {
                 room->broadcastSkillInvoke(objectName());
-                target->obtainCard(damage.from->getWeapon());
+                if ((damage.from->hasSkill("wanwei") || damage.from->getMark("wanwei") != 0) && room->askForSkillInvoke(damage.from, "wanwei")) {
+                    room->broadcastSkillInvoke("wanwei");
+                    target->obtainCard(room->askForCard(damage.from, "..!", "@wanwei", QVariant(), Card::MethodNone));
+                } else {
+                    target->obtainCard(damage.from->getWeapon());
+                }
             }
         }
     }

--- a/src/package/yjcm2015.cpp
+++ b/src/package/yjcm2015.cpp
@@ -231,7 +231,7 @@ public:
                     room->broadcastSkillInvoke(objectName());
                     room->setPlayerFlag(player, "TaoxiUsed");
                     room->setPlayerFlag(player, "TaoxiRecord");
-                    int id = room->askForCardChosen(player, to, "h", objectName(), false);
+                    int id = room->askForCardChosen(player, to, "h", objectName(), false, Card::MethodNone, QList<int>(), false, false);
                     room->showCard(to, id);
                     TaoxiMove(id, true, player);
                     player->tag["TaoxiId"] = id;
@@ -867,7 +867,15 @@ void ZhenshanCard::askForExchangeHand(ServerPlayer *quancong)
     }
     if (!target->isKongcheng()) {
         CardMoveReason reason(CardMoveReason::S_REASON_SWAP, target->objectName(), quancong->objectName(), "zhenshan", QString());
-        CardsMoveStruct move(target->handCards(), quancong, Player::PlaceHand, reason);
+        QList<int> ids = target->handCards();
+        if ((target->hasSkill("wanwei") || target->getMark("wanwei") != 0) && room->askForSkillInvoke(target, "wanwei")) {
+            room->broadcastSkillInvoke("wanwei");
+            const Card *exchange_card = room->askForExchange(target, "wanwei", target->getHandcardNum(), target->getHandcardNum(), true, "@wanwei!");
+            ids.clear();
+            foreach(int i, exchange_card->getSubcards())
+                ids << i;
+        }
+        CardsMoveStruct move(ids, quancong, Player::PlaceHand, reason);
         moves << move;
     }
     if (!moves.isEmpty())

--- a/src/server/gamerule.cpp
+++ b/src/server/gamerule.cpp
@@ -221,6 +221,9 @@ bool GameRule::trigger(TriggerEvent triggerEvent, Room *room, ServerPlayer *play
     case EventPhaseEnd: {
         if (player->getPhase() == Player::Play)
             room->addPlayerHistory(player, ".");
+        if (player->getPhase() == Player::NotActive) {
+            room->addPlayerHistory(player, "Analeptic", 0);     //clear Analeptic
+        }
         break;
     }
     case EventPhaseChanging: {

--- a/src/server/room.h
+++ b/src/server/room.h
@@ -1,4 +1,4 @@
-﻿#ifndef _ROOM_H
+#ifndef _ROOM_H
 #define _ROOM_H
 
 class TriggerSkill;
@@ -103,7 +103,7 @@ public:
     ServerPlayer *getLord() const;
     void askForGuanxing(ServerPlayer *zhuge, const QList<int> &cards, GuanxingType guanxing_type = GuanxingBothSides);
     void returnToTopDrawPile(const QList<int> &cards);
-    int doGongxin(ServerPlayer *shenlvmeng, ServerPlayer *target, QList<int> enabled_ids = QList<int>(), QString skill_name = "gongxin");
+    int doGongxin(ServerPlayer *shenlvmeng, ServerPlayer *target, QList<int> enabled_ids = QList<int>(), QString skill_name = "gongxin", bool wanwei = true);
     int drawCard();
     void fillAG(const QList<int> &card_ids, ServerPlayer *who = NULL, const QList<int> &disabled_ids = QList<int>());
     void takeAG(ServerPlayer *player, int card_id, bool move_cards = true, QList<ServerPlayer *> to_notify = QList<ServerPlayer *>());
@@ -338,8 +338,8 @@ public:
         bool include_equip = false, const QString &prompt = QString(), bool optional = false, const QString &pattern = ".");
     bool askForNullification(const Card *trick, ServerPlayer *from, ServerPlayer *to, bool positive);
     bool isCanceled(const CardEffectStruct &effect);
-    int askForCardChosen(ServerPlayer *player, ServerPlayer *who, const QString &flags, const QString &reason,
-        bool handcard_visible = false, Card::HandlingMethod method = Card::MethodNone, const QList<int> &disabled_ids = QList<int>());
+    int askForCardChosen(ServerPlayer *player, ServerPlayer *who,const QString &flags, const QString &reason,
+        bool handcard_visible = false, Card::HandlingMethod method = Card::MethodNone, const QList<int> &disabled_ids = QList<int>(), bool obtain = false, bool wanwei = true);
     const Card *askForCard(ServerPlayer *player, const QString &pattern, const QString &prompt, const QVariant &data, const QString &skill_name);
     const Card *askForCard(ServerPlayer *player, const QString &pattern, const QString &prompt, const QVariant &data = QVariant(),
         Card::HandlingMethod method = Card::MethodDiscard, ServerPlayer *to = NULL, bool isRetrial = false,

--- a/src/server/serverplayer.h
+++ b/src/server/serverplayer.h
@@ -34,7 +34,7 @@ public:
     int getRandomHandCardId() const;
     const Card *getRandomHandCard() const;
     void obtainCard(const Card *card, bool unhide = true);
-    void throwAllEquips();
+    void throwAllEquips(bool wanwei = true);
     void throwAllHandCards();
     void throwAllHandCardsAndEquips();
     void throwAllCards();
@@ -49,7 +49,7 @@ public:
     QList<int> handCards() const;
     virtual QList<const Card *> getHandcards() const;
     QList<const Card *> getCards(const QString &flags) const;
-    DummyCard *wholeHandCards() const;
+    DummyCard *wholeHandCards(bool wanwei = false);
     bool hasNullification() const;
     bool pindian(ServerPlayer *target, const QString &reason, const Card *card1 = NULL);
     void turnOver();


### PR DESCRIPTION
新增对受伤的判断——player:getMark("I_am_Wounded") > 0
askForCardChosen新增参数 obtain 和 wanwei——obtain判断此次选择是否为获得牌，wanwei为判断此次选择是否为弃置或获得牌
doGongxin、throwAllEquips、wholeHandCards添加参数均为了判定是否可以发动挽危
新增对神吕布技能配音的耦合、修改沮授、纪灵、张松配音播放策略
酒的使用持续效果改为一回合
五谷丰登亮出牌数改为目标数
修复五星诸葛那蛋疼的bug（笑）
修复神司马懿连破log的bug（笑）
修复OL张角雷击不传导bug 声明：ai不会用OL雷击是因为没有ai，请会写ai的大神帮忙补上
修复涅槃、伏枥、新不屈不终止处于濒死状态时机bug
修复奔袭断肠后不存在距离减少buff的bug
修复将驰、旧裸衣、1V1突袭、弘援没有牌摸的场合可以少摸牌bug
修复献州选项以及发动原因bug
修复OL清俭、OL安恤bug
修复巧说判断问题
凤魄造成伤害时机提前
修复默识读取延时类锦囊bug
修复窃听判断相关bug
